### PR TITLE
ES6 Friendly Class Extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "p5",
   "repository": "processing/p5.js",
   "scripts": {
+    "prepare": "npm run docs; npm run build",
     "grunt": "grunt",
     "build": "grunt build",
     "dev": "grunt browserify connect:yui watch:quick",

--- a/src/core/main.js
+++ b/src/core/main.js
@@ -42,6 +42,15 @@ var p5 = function(sketch, node, sync) {
     node = undefined;
   }
 
+  var extendsClass = false;
+
+  if (
+    (this.setup && this.draw && typeof this.setup === 'function',
+    typeof this.draw === 'function')
+  ) {
+    extendsClass = true;
+  }
+
   //////////////////////////////////////////////
   // PUBLIC p5 PROPERTIES AND METHODS
   //////////////////////////////////////////////
@@ -493,7 +502,7 @@ var p5 = function(sketch, node, sync) {
 
   // If the user has created a global setup or draw function,
   // assume "global" mode and make everything global (i.e. on the window)
-  if (!sketch) {
+  if (!sketch && !extendsClass) {
     this._isGlobal = true;
     p5.instance = this;
     // Loop through methods on the prototype and attach them to the window
@@ -519,7 +528,7 @@ var p5 = function(sketch, node, sync) {
         friendlyBindGlobal(p2, this[p2]);
       }
     }
-  } else {
+  } else if (sketch && !extendsClass) {
     // Else, the user has passed in a sketch closure that may set
     // user-provided 'setup', 'draw', etc. properties on this instance of p5
     sketch(this);


### PR DESCRIPTION
This PR adds support for extending ES6 classes with P5. A custom class can inherit from P5. This inheritance allows a user to:
1. Define `setup` and `draw` functions as normal class methods instead of modifying the P5 instance.
2. Access all P5 functions through `this`.

Example:
https://gist.github.com/bigmstone/fe1c002f54e876a4ecc876df3435f100